### PR TITLE
feat: add support for custom Anthropic API base URL

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -30,6 +30,7 @@ ANNOTATE=$(plugin_read_config ANNOTATE "true")
 AGENT_FILE=$(plugin_read_config AGENT_FILE "false")
 COMPARE_BUILDS=$(plugin_read_config COMPARE_BUILDS "false")
 COMPARISON_RANGE=$(plugin_read_config COMPARISON_RANGE "5")
+ANTHROPIC_BASE_URL=$(plugin_read_config ANTHROPIC_BASE_URL "https://api.anthropic.com")
 
 # API key validation already done above - no need to check again
 
@@ -41,7 +42,7 @@ COMPARISON_RANGE=$(plugin_read_config COMPARISON_RANGE "5")
 validate_tools || exit 1
 
 # Validate configuration
-validate_configuration "${API_KEY}" "${MODEL}" "${TRIGGER}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "$(plugin_read_config BUILDKITE_API_TOKEN "")" || exit 1
+validate_configuration "${API_KEY}" "${MODEL}" "${TRIGGER}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "$(plugin_read_config BUILDKITE_API_TOKEN "")" "${ANTHROPIC_BASE_URL}" || exit 1
 
 echo "--- :robot_face: Claude Code Plugin (Post-Command)"
 echo "Model: ${MODEL}"
@@ -64,7 +65,7 @@ if should_trigger_analysis "${TRIGGER}" "${COMMAND_EXIT_STATUS}"; then
 
   # Perform analysis (disable exit on error temporarily)
   set +e
-  ANALYSIS=$(analyze_build_failure "${API_KEY}" "${MODEL}" "${MAX_LOG_LINES}" "${CUSTOM_PROMPT}" "${TIMEOUT}" "${AGENT_FILE}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
+  ANALYSIS=$(analyze_build_failure "${API_KEY}" "${MODEL}" "${MAX_LOG_LINES}" "${CUSTOM_PROMPT}" "${TIMEOUT}" "${AGENT_FILE}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}" "${ANTHROPIC_BASE_URL}")
   ANALYSIS_EXIT_CODE=$?
   set -e
 
@@ -167,7 +168,7 @@ $([ "${COMPARE_BUILDS}" = "true" ] && echo "- Historical Comparison: Last ${COMP
 
 **Resolution Steps:**
 1. Verify your Anthropic API key is correctly configured
-2. Check network connectivity to \`api.anthropic.com\`
+2. Check network connectivity to your configured Anthropic API endpoint
 3. Ensure the Buildkite agent has internet access
 4. Visit [status.anthropic.com](https://status.anthropic.com/) to check service status
 

--- a/lib/validation.bash
+++ b/lib/validation.bash
@@ -10,6 +10,7 @@ function validate_configuration() {
   local analysis_level="$4"
   local compare_builds="$5"
   local buildkite_api_token="$6"
+  local anthropic_base_url="$7"
   
   local errors=0
   
@@ -34,6 +35,12 @@ function validate_configuration() {
   # Validate analysis_level
   if [[ ! "${analysis_level}" =~ ^(step|build)$ ]]; then
     echo "❌ Error: analysis_level must be one of: step, build. Got: ${analysis_level}" >&2
+    errors=$((errors + 1))
+  fi
+  
+  # Validate anthropic_base_url format
+  if [[ ! "${anthropic_base_url}" =~ ^https?:// ]]; then
+    echo "❌ Error: anthropic_base_url must start with http:// or https://. Got: ${anthropic_base_url}" >&2
     errors=$((errors + 1))
   fi
   

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,10 @@ configuration:
     buildkite_api_token:
       type: string
       description: Buildkite API token for fetching job logs (optional, will use environment BUILDKITE_API_TOKEN if not specified)
+    anthropic_base_url:
+      type: string
+      description: Custom Anthropic API base URL (optional, defaults to https://api.anthropic.com)
+      default: https://api.anthropic.com
     model:
       type: string
       description: Claude model to use

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -13,52 +13,59 @@ setup() {
 }
 
 @test "Validate configuration succeeds with valid inputs" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "false" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "false" "" "https://api.anthropic.com"
   
   assert_success
   refute_output --partial "Error"
 }
 
 @test "Validate configuration fails with missing API key" {
-  run validate_configuration "" "claude-3-opus" "on-failure" "step" "false" ""
+  run validate_configuration "" "claude-3-opus" "on-failure" "step" "false" "" "https://api.anthropic.com"
   
   assert_failure
   assert_output --partial "Error: api_key is required"
 }
 
 @test "Validate configuration fails with invalid model" {
-  run validate_configuration "sk-ant-test-key" "not-claude" "on-failure" "step" "false" ""
+  run validate_configuration "sk-ant-test-key" "not-claude" "on-failure" "step" "false" "" "https://api.anthropic.com"
   
   assert_failure
   assert_output --partial "Error: model must be a valid Claude model"
 }
 
 @test "Validate configuration fails with invalid trigger" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "invalid-trigger" "step" "false" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "invalid-trigger" "step" "false" "" "https://api.anthropic.com"
   
   assert_failure
   assert_output --partial "Error: trigger must be one of: on-failure, always, manual"
 }
 
 @test "Validate configuration fails with invalid analysis level" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "invalid-level" "false" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "invalid-level" "false" "" "https://api.anthropic.com"
   
   assert_failure
   assert_output --partial "Error: analysis_level must be one of: step, build"
 }
 
 @test "Validate configuration warns about missing API token for build level" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "build" "false" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "build" "false" "" "https://api.anthropic.com"
   
   assert_success
   assert_output --partial "Warning: build-level analysis works best with a Buildkite API token"
 }
 
 @test "Validate configuration warns about missing API token for build comparison" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "true" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "true" "" "https://api.anthropic.com"
   
   assert_success
   assert_output --partial "Warning: build comparison requires a Buildkite API token"
+}
+
+@test "Validate configuration fails with invalid base URL" {
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "false" "" "invalid-url"
+  
+  assert_failure
+  assert_output --partial "Error: anthropic_base_url must start with http:// or https://"
 }
 
 @test "Validate tools succeeds with available tools" {


### PR DESCRIPTION
Add support a custom ANTHROPIC_BASE_URL variable. This allow access from an llm proxy such as LiteLLM or other alternative providers of the API.

https://github.com/buildkite-plugins/claude-summarize-buildkite-plugin/issues/5