### PR TITLE
Rename plugin prefix from CLAUDE_CODE to CLAUDE_SUMMARIZE

### DIFF
--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-PLUGIN_PREFIX="CLAUDE_CODE"
+PLUGIN_PREFIX="CLAUDE_SUMMARIZE"
 
 # Get the Buildkite API token from environment or plugin config
 function get_buildkite_api_token() {


### PR DESCRIPTION
Hi team, I am trying out this plugin and running into an issue when following the getting started:
> ❌ Error: api_key is required for Claude Code plugin


After some debugging we think it might be this prefix wasn't updated as part of the rename to claud-summarize, causing it to not be able to find the api_key in the environment.

How to reproduce:
Add a step in your pipeline to use the plugin like the getting starting suggests:
>  - label: "🧪 Run tests"
    command: "npm test"
    plugins:
      - claude-summarize#v1.0.0:
          api_key: "$$ANTHROPIC_API_KEY"