### PR TITLE
Fix remaining plugin-name issues

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -11,5 +11,5 @@ API_KEY=$(plugin_read_config API_KEY "")
 
 # Export API key if provided
 if [[ -n "$API_KEY" ]]; then
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="$API_KEY"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="$API_KEY"
 fi

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-PLUGIN_PREFIX="CLAUDE_CODE"
+PLUGIN_PREFIX="CLAUDE_SUMMARIZE"
 
 # Get the Buildkite API token from environment or plugin config
 function get_buildkite_api_token() {

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -13,48 +13,60 @@ setup() {
 
 teardown() {
   # Clean up environment variables
-  unset BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY
+  unset BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY
   unset TEST_ENV_VAR
   unset EMPTY_ENV_VAR
 }
 
 @test "Environment hook exports API key when provided" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="sk-ant-test-key"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="sk-ant-test-key"
 
   # Source the environment hook
   source "$PWD"/hooks/environment
 
   # Check that the API key is exported
-  [ "${BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY}" = "sk-ant-test-key" ]
+  [ "${BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY}" = "sk-ant-test-key" ]
 }
 
 @test "Environment hook handles empty API_KEY gracefully" {
   # Don't set API_KEY to test behavior
-  unset BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY
+  unset BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY
 
   # Source the environment hook
   source "$PWD"/hooks/environment
 
   # API_KEY should not be set if not provided
-  [ -z "${BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY:-}" ]
+  [ -z "${BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY:-}" ]
 }
 
 @test "Environment hook preserves literal values" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="literal-key-value"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="literal-key-value"
 
   # Source the environment hook
   source "$PWD"/hooks/environment
 
   # Check that literal values are preserved
-  [ "${BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY}" = "literal-key-value" ]
+  [ "${BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY}" = "literal-key-value" ]
 }
 
 @test "Environment hook handles special characters in API key" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="sk-ant-key-with-special-chars_123"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="sk-ant-key-with-special-chars_123"
 
   # Source the environment hook
   source "$PWD"/hooks/environment
 
   # Check that special characters are preserved
-  [ "${BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY}" = "sk-ant-key-with-special-chars_123" ]
+  [ "${BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY}" = "sk-ant-key-with-special-chars_123" ]
+}
+
+@test "Plugin name and prefix are correct" {
+  PLUGIN_NAME=$(grep -E '^name:' "./plugin.yml" | awk '{ $1=""; sub(/^ /,""); print }')
+
+  source "$PWD"/lib/plugin.bash
+
+  # Check that the name is correct in the YAML file
+  [ "${PLUGIN_NAME}" = "Claude Summarize" ]
+
+  # Check that the prefix is correct in the plugin script
+  [ "${PLUGIN_PREFIX}" = "CLAUDE_SUMMARIZE" ]
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -6,7 +6,7 @@ setup() {
   load "${BATS_PLUGIN_PATH}/load.bash"
 
   # Common test variables
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY='sk-ant-test-key'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY='sk-ant-test-key'
   export BUILDKITE_COMMAND_EXIT_STATUS='1'  # Simulate failure for most tests
   export BUILDKITE_BUILD_ID='test-build-123'
   export BUILDKITE_JOB_ID='test-job-456'
@@ -45,7 +45,7 @@ teardown() {
 }
 
 @test "Missing API key fails" {
-  unset BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY
+  unset BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY
 
   run "$PWD"/hooks/post-command
 
@@ -77,7 +77,7 @@ teardown() {
 }
 
 @test "Plugin runs on success with always trigger" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_TRIGGER='always'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_TRIGGER='always'
   export BUILDKITE_COMMAND_EXIT_STATUS='0'
 
   run "$PWD"/hooks/post-command
@@ -89,7 +89,7 @@ teardown() {
 }
 
 @test "Plugin respects manual trigger with environment variable" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_TRIGGER='manual'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_TRIGGER='manual'
   export CLAUDE_ANALYZE='true'
 
   run "$PWD"/hooks/post-command
@@ -100,7 +100,7 @@ teardown() {
 }
 
 @test "Plugin skips manual trigger without environment variable" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_TRIGGER='manual'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_TRIGGER='manual'
   export BUILDKITE_COMMAND_EXIT_STATUS='1'
 
   run "$PWD"/hooks/post-command
@@ -112,7 +112,7 @@ teardown() {
 }
 
 @test "Plugin respects manual trigger with commit message" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_TRIGGER='manual'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_TRIGGER='manual'
   export BUILDKITE_MESSAGE='Fix bug [claude-analyze] in authentication'
 
   run "$PWD"/hooks/post-command
@@ -123,7 +123,7 @@ teardown() {
 }
 
 @test "Plugin uses custom model" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_MODEL='claude-3-opus-20240229'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_MODEL='claude-3-opus-20240229'
 
   run "$PWD"/hooks/post-command
 
@@ -132,7 +132,7 @@ teardown() {
 }
 
 @test "Plugin uses custom max log lines" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_MAX_LOG_LINES='500'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_MAX_LOG_LINES='500'
 
   run "$PWD"/hooks/post-command
 
@@ -141,7 +141,7 @@ teardown() {
 }
 
 @test "Plugin handles custom prompt" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_CUSTOM_PROMPT='Focus on Node.js issues'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_CUSTOM_PROMPT='Focus on Node.js issues'
 
   run "$PWD"/hooks/post-command
 
@@ -150,7 +150,7 @@ teardown() {
 }
 
 @test "Plugin can disable annotations" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_ANNOTATE='false'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANNOTATE='false'
 
   run "$PWD"/hooks/post-command
 
@@ -165,7 +165,7 @@ teardown() {
 }
 
 @test "Plugin uses API token from configuration" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_BUILDKITE_API_TOKEN='bk-test-token'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILDKITE_API_TOKEN='bk-test-token'
   export BUILDKITE_API_TOKEN='' # Ensure environment token is empty
 
   run "$PWD"/hooks/post-command
@@ -176,7 +176,7 @@ teardown() {
 
 @test "Plugin works with environment variable API key format" {
   export TEST_API_KEY='sk-ant-env-test-key'
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="${TEST_API_KEY}"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="${TEST_API_KEY}"
 
   run "$PWD"/hooks/post-command
 
@@ -187,10 +187,10 @@ teardown() {
 
 @test "Plugin works with Buildkite secret API key format" {
   # Set API key directly for simplicity
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY="sk-ant-test-from-secret"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY="sk-ant-test-from-secret"
 
   # Pretend this came from a secret
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY_SOURCE="buildkite-secret"
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY_SOURCE="buildkite-secret"
 
   run "$PWD"/hooks/post-command
 
@@ -201,7 +201,7 @@ teardown() {
 
 @test "Plugin works with literal API key format" {
   # Test that the new unified API key configuration works with literal values
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_API_KEY='sk-ant-literal-test-key'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_API_KEY='sk-ant-literal-test-key'
 
   run "$PWD"/hooks/post-command
 
@@ -211,7 +211,7 @@ teardown() {
 }
 
 @test "Plugin uses custom anthropic base URL" {
-  export BUILDKITE_PLUGIN_CLAUDE_CODE_ANTHROPIC_BASE_URL='https://custom-claude-api.company.com'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANTHROPIC_BASE_URL='https://custom-claude-api.company.com'
 
   run "$PWD"/hooks/post-command
 


### PR DESCRIPTION
Updates remaining references to the previous name (`CLAUDE_CODE` -> `CLAUDE_SUMMARIZE`) and adds a test that ensures both the plugin name and prefix are set correctly.

Fixes #12
