### PR TITLE
Allow analyzing only failed jobs on `build` analysis_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Level at which to analyze logs. Options: `step`, `build`. These require `buildki
 - `step`: Analyze only the current step's logs
 - `build`: Analyze logs from all jobs in the entire build
 
+#### `build_log_mode` (string)
+
+When `analysis_level` is `build`, controls which job logs to fetch. Options: `failed`, `all`. Default: `failed`
+
+- `failed`: Only fetch logs from failed jobs (reduces token usage significantly for large builds)
+- `all`: Fetch logs from all jobs in the build
+
+This option helps avoid hitting Claude API token limits when analyzing builds with many jobs. With `failed` mode, the plugin includes a summary of all jobs (with their pass/fail status) but only fetches detailed logs for failed jobs.
+
 #### `max_log_lines` (integer)
 
 Maximum number of log lines to send to Claude for analysis. Default: `1000`
@@ -160,6 +169,20 @@ steps:
 ```
 
 With `analysis_level: "build"`, Claude will analyze logs from all jobs in the build, providing insights across the entire pipeline.
+
+By default, only logs from **failed jobs** are fetched to reduce token usage. If you need logs from all jobs, set `build_log_mode: "all"`:
+
+```yaml
+steps:
+  - label: "🔍 Analyze entire build (all jobs)"
+    command: "npm test"
+    plugins:
+      - claude-summarize#v1.1.0:
+          api_key: "$$ANTHROPIC_API_KEY"
+          buildkite_api_token: "$$BUILDKITE_API_TOKEN"
+          analysis_level: "build"
+          build_log_mode: "all"
+```
 
 ### Always Analyze Builds
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ Level at which to analyze logs. Options: `step`, `build`. These require `buildki
 
 #### `build_log_mode` (string)
 
-When `analysis_level` is `build`, controls which job logs to fetch. Options: `failed`, `all`. Default: `failed`
+When `analysis_level` is `build`, controls which job logs to fetch. Options: `failed`, `all`. Default: `all`
 
-- `failed`: Only fetch logs from failed jobs (reduces token usage significantly for large builds)
 - `all`: Fetch logs from all jobs in the build
+- `failed`: Only fetch logs from failed jobs (reduces token usage significantly for large builds)
 
-This option helps avoid hitting Claude API token limits when analyzing builds with many jobs. With `failed` mode, the plugin includes a summary of all jobs (with their pass/fail status) but only fetches detailed logs for failed jobs.
+Use `failed` mode to avoid hitting Claude API token limits when analyzing builds with many jobs. With `failed` mode, the plugin includes a summary of all jobs (with their pass/fail status) but only fetches detailed logs for failed jobs.
 
 #### `max_log_lines` (integer)
 
@@ -170,18 +170,18 @@ steps:
 
 With `analysis_level: "build"`, Claude will analyze logs from all jobs in the build, providing insights across the entire pipeline.
 
-By default, only logs from **failed jobs** are fetched to reduce token usage. If you need logs from all jobs, set `build_log_mode: "all"`:
+To reduce token usage on large builds, you can set `build_log_mode: "failed"` to only fetch logs from failed jobs:
 
 ```yaml
 steps:
-  - label: "🔍 Analyze entire build (all jobs)"
+  - label: "🔍 Analyze entire build (failed jobs only)"
     command: "npm test"
     plugins:
       - claude-summarize#v1.1.0:
           api_key: "$$ANTHROPIC_API_KEY"
           buildkite_api_token: "$$BUILDKITE_API_TOKEN"
           analysis_level: "build"
-          build_log_mode: "all"
+          build_log_mode: "failed"
 ```
 
 ### Always Analyze Builds

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -23,6 +23,7 @@ fi
 MODEL=$(plugin_read_config MODEL "claude-3-7-sonnet-20250219")
 TRIGGER=$(plugin_read_config TRIGGER "on-failure")
 ANALYSIS_LEVEL=$(plugin_read_config ANALYSIS_LEVEL "step")
+BUILD_LOG_MODE=$(plugin_read_config BUILD_LOG_MODE "failed")
 MAX_LOG_LINES=$(plugin_read_config MAX_LOG_LINES "1000")
 CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
 TIMEOUT=$(plugin_read_config TIMEOUT "60")
@@ -41,12 +42,13 @@ COMPARISON_RANGE=$(plugin_read_config COMPARISON_RANGE "5")
 validate_tools || exit 1
 
 # Validate configuration
-validate_configuration "${API_KEY}" "${MODEL}" "${TRIGGER}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "$(plugin_read_config BUILDKITE_API_TOKEN "")" || exit 1
+validate_configuration "${API_KEY}" "${MODEL}" "${TRIGGER}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "$(plugin_read_config BUILDKITE_API_TOKEN "")" "${BUILD_LOG_MODE}" || exit 1
 
 echo "--- :robot_face: Claude Code Plugin (Post-Command)"
 echo "Model: ${MODEL}"
 echo "Trigger: ${TRIGGER}"
 echo "Analysis Level: ${ANALYSIS_LEVEL}"
+[ "${ANALYSIS_LEVEL}" = "build" ] && echo "Build Log Mode: ${BUILD_LOG_MODE}"
 echo "Max log lines: ${MAX_LOG_LINES}"
 [ "${COMPARE_BUILDS}" = "true" ] && echo "Build Comparison: ENABLED (last ${COMPARISON_RANGE} builds)" || echo "Build Comparison: disabled"
 
@@ -64,7 +66,7 @@ if should_trigger_analysis "${TRIGGER}" "${COMMAND_EXIT_STATUS}"; then
 
   # Perform analysis (disable exit on error temporarily)
   set +e
-  ANALYSIS=$(analyze_build_failure "${API_KEY}" "${MODEL}" "${MAX_LOG_LINES}" "${CUSTOM_PROMPT}" "${TIMEOUT}" "${AGENT_FILE}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}")
+  ANALYSIS=$(analyze_build_failure "${API_KEY}" "${MODEL}" "${MAX_LOG_LINES}" "${CUSTOM_PROMPT}" "${TIMEOUT}" "${AGENT_FILE}" "${ANALYSIS_LEVEL}" "${COMPARE_BUILDS}" "${COMPARISON_RANGE}" "${BUILD_LOG_MODE}")
   ANALYSIS_EXIT_CODE=$?
   set -e
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -23,7 +23,7 @@ fi
 MODEL=$(plugin_read_config MODEL "claude-3-7-sonnet-20250219")
 TRIGGER=$(plugin_read_config TRIGGER "on-failure")
 ANALYSIS_LEVEL=$(plugin_read_config ANALYSIS_LEVEL "step")
-BUILD_LOG_MODE=$(plugin_read_config BUILD_LOG_MODE "failed")
+BUILD_LOG_MODE=$(plugin_read_config BUILD_LOG_MODE "all")
 MAX_LOG_LINES=$(plugin_read_config MAX_LOG_LINES "1000")
 CUSTOM_PROMPT=$(plugin_read_config CUSTOM_PROMPT "")
 TIMEOUT=$(plugin_read_config TIMEOUT "60")

--- a/lib/logs.bash
+++ b/lib/logs.bash
@@ -51,6 +51,7 @@ function get_build_logs_internal() {
   local api_token="$1"
   local max_lines="$2"
   local log_file="$3"
+  local build_log_mode="${4:-failed}"
 
   # Validate parameters
   if [ -z "${api_token}" ] || [ -z "${max_lines}" ] || [ -z "${log_file}" ]; then
@@ -63,14 +64,40 @@ function get_build_logs_internal() {
   local build_data_file="/tmp/build_${BUILDKITE_BUILD_ID}.json"
 
   if curl -s -f -H "Authorization: Bearer ${api_token}" "${build_url}" > "${build_data_file}" 2>/dev/null; then
-    # Extract job IDs from the build
+    # Extract job IDs from the build based on build_log_mode
     if command -v jq >/dev/null 2>&1; then
       local job_ids
-      job_ids=$(jq -r '.jobs[].id' "${build_data_file}" 2>/dev/null)
+
+      if [ "${build_log_mode}" = "failed" ]; then
+        # Filter for jobs with non-zero exit_status (failed jobs only)
+        job_ids=$(jq -r '.jobs[] | select(.exit_status != null and .exit_status != 0) | .id' "${build_data_file}" 2>/dev/null)
+
+        # If no failed jobs found, fall back to getting all completed jobs
+        if [ -z "${job_ids}" ]; then
+          job_ids=$(jq -r '.jobs[] | select(.exit_status != null) | .id' "${build_data_file}" 2>/dev/null)
+        fi
+      else
+        job_ids=$(jq -r '.jobs[].id' "${build_data_file}" 2>/dev/null)
+      fi
 
       if [ -n "${job_ids}" ]; then
         # Create a combined log file
         : > "${log_file}"
+
+        # Add a summary header showing all jobs and their status
+        {
+          echo "========================================"
+          echo "BUILD JOBS SUMMARY"
+          echo "========================================"
+          jq -r '.jobs[] | "- \(.name // "Unnamed job"): exit_status=\(.exit_status // "pending"), state=\(.state // "unknown")"' "${build_data_file}" 2>/dev/null
+          echo ""
+          if [ "${build_log_mode}" = "failed" ]; then
+            echo "Note: Fetching detailed logs only for FAILED jobs to reduce token usage."
+          else
+            echo "Note: Fetching detailed logs for ALL completed jobs."
+          fi
+          echo ""
+        } >> "${log_file}"
 
         # Process each job
         local job_count=0
@@ -249,6 +276,7 @@ function fetch_build_logs() {
   local api_token="$1"
   local max_lines="$2"
   local analysis_level="$3"
+  local build_log_mode="${4:-failed}"
 
   # Validate parameters
   if [ -z "${max_lines}" ] || [ -z "${analysis_level}" ]; then
@@ -269,7 +297,7 @@ function fetch_build_logs() {
   # For build-level analysis, try to get all jobs in the build
   if [ "${analysis_level}" = "build" ]; then
     if [ -n "${api_token}" ]; then
-      if get_build_logs_internal "${api_token}" "${max_lines}" "${log_file}"; then
+      if get_build_logs_internal "${api_token}" "${max_lines}" "${log_file}" "${build_log_mode}"; then
         echo "${log_file}"
         return 0
       fi

--- a/lib/logs.bash
+++ b/lib/logs.bash
@@ -51,7 +51,7 @@ function get_build_logs_internal() {
   local api_token="$1"
   local max_lines="$2"
   local log_file="$3"
-  local build_log_mode="${4:-failed}"
+  local build_log_mode="${4:-all}"
 
   # Validate parameters
   if [ -z "${api_token}" ] || [ -z "${max_lines}" ] || [ -z "${log_file}" ]; then
@@ -276,7 +276,7 @@ function fetch_build_logs() {
   local api_token="$1"
   local max_lines="$2"
   local analysis_level="$3"
-  local build_log_mode="${4:-failed}"
+  local build_log_mode="${4:-all}"
 
   # Validate parameters
   if [ -z "${max_lines}" ] || [ -z "${analysis_level}" ]; then

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -77,12 +77,13 @@ function plugin_read_config() {
 function get_build_logs() {
   local max_lines="${1:-1000}"
   local analysis_level="${2:-step}"
+  local build_log_mode="${3:-failed}"
   local api_token
   api_token="$(get_buildkite_api_token)"
 
   # Call the refactored implementation
   local log_file
-  if log_file=$(fetch_build_logs "${api_token}" "${max_lines}" "${analysis_level}"); then
+  if log_file=$(fetch_build_logs "${api_token}" "${max_lines}" "${analysis_level}" "${build_log_mode}"); then
     echo "${log_file}"
     return 0
   else
@@ -466,6 +467,7 @@ function analyze_build_failure() {
   local analysis_level="${7:-step}"
   local compare_builds="${8:-false}"
   local comparison_range="${9:-5}"
+  local build_log_mode="${10:-failed}"
 
   # Get build information
   local build_info="Build: ${BUILDKITE_PIPELINE_SLUG} #${BUILDKITE_BUILD_NUMBER}
@@ -591,7 +593,7 @@ Build Duration (so far): ${current_build_time}s"
 
   # Get logs based on analysis level
   local log_file
-  if ! log_file=$(get_build_logs "${max_log_lines}" "${analysis_level}"); then
+  if ! log_file=$(get_build_logs "${max_log_lines}" "${analysis_level}" "${build_log_mode}"); then
     echo "Error: Failed to retrieve build logs" >&2
     return 1
   fi

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -77,7 +77,7 @@ function plugin_read_config() {
 function get_build_logs() {
   local max_lines="${1:-1000}"
   local analysis_level="${2:-step}"
-  local build_log_mode="${3:-failed}"
+  local build_log_mode="${3:-all}"
   local api_token
   api_token="$(get_buildkite_api_token)"
 
@@ -467,7 +467,7 @@ function analyze_build_failure() {
   local analysis_level="${7:-step}"
   local compare_builds="${8:-false}"
   local comparison_range="${9:-5}"
-  local build_log_mode="${10:-failed}"
+  local build_log_mode="${10:-all}"
 
   # Get build information
   local build_info="Build: ${BUILDKITE_PIPELINE_SLUG} #${BUILDKITE_BUILD_NUMBER}

--- a/lib/validation.bash
+++ b/lib/validation.bash
@@ -10,7 +10,7 @@ function validate_configuration() {
   local analysis_level="$4"
   local compare_builds="$5"
   local buildkite_api_token="$6"
-  local build_log_mode="${7:-failed}"
+  local build_log_mode="${7:-all}"
 
   local errors=0
 

--- a/lib/validation.bash
+++ b/lib/validation.bash
@@ -10,30 +10,37 @@ function validate_configuration() {
   local analysis_level="$4"
   local compare_builds="$5"
   local buildkite_api_token="$6"
-  
+  local build_log_mode="${7:-failed}"
+
   local errors=0
-  
+
   # Check required configuration
   if [ -z "${api_key}" ]; then
     echo "❌ Error: api_key is required for Claude Code plugin" >&2
     errors=$((errors + 1))
   fi
-  
+
   # Validate model format
   if [[ ! "${model}" =~ ^claude- ]]; then
     echo "❌ Error: model must be a valid Claude model starting with 'claude-'" >&2
     errors=$((errors + 1))
   fi
-  
+
   # Validate trigger
   if [[ ! "${trigger}" =~ ^(on-failure|always|manual)$ ]]; then
     echo "❌ Error: trigger must be one of: on-failure, always, manual. Got: ${trigger}" >&2
     errors=$((errors + 1))
   fi
-  
+
   # Validate analysis_level
   if [[ ! "${analysis_level}" =~ ^(step|build)$ ]]; then
     echo "❌ Error: analysis_level must be one of: step, build. Got: ${analysis_level}" >&2
+    errors=$((errors + 1))
+  fi
+
+  # Validate build_log_mode
+  if [[ ! "${build_log_mode}" =~ ^(failed|all)$ ]]; then
+    echo "❌ Error: build_log_mode must be one of: failed, all. Got: ${build_log_mode}" >&2
     errors=$((errors + 1))
   fi
   

--- a/plugin.yml
+++ b/plugin.yml
@@ -30,6 +30,11 @@ configuration:
       description: Level at which to analyze logs - 'step' for current step only, 'build' for all jobs in the build
       enum: ["step", "build"]
       default: step
+    build_log_mode:
+      type: string
+      description: When analysis_level is 'build', controls which job logs to fetch - 'failed' for only failed jobs (reduces token usage), 'all' for all jobs
+      enum: ["failed", "all"]
+      default: failed
     max_log_lines:
       type: integer
       description: Maximum number of log lines to analyze

--- a/plugin.yml
+++ b/plugin.yml
@@ -34,7 +34,7 @@ configuration:
       type: string
       description: When analysis_level is 'build', controls which job logs to fetch - 'failed' for only failed jobs (reduces token usage), 'all' for all jobs
       enum: ["failed", "all"]
-      default: failed
+      default: all
     max_log_lines:
       type: integer
       description: Maximum number of log lines to analyze

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -228,19 +228,19 @@ teardown() {
 
   assert_success
   assert_output --partial 'Analysis Level: build'
-  assert_output --partial 'Build Log Mode: failed'
+  assert_output --partial 'Build Log Mode: all'
 }
 
 @test "Plugin uses custom build_log_mode" {
   export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANALYSIS_LEVEL='build'
-  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILD_LOG_MODE='all'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILD_LOG_MODE='failed'
   export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILDKITE_API_TOKEN='bk-test-token'
 
   run "$PWD"/hooks/post-command
 
   assert_success
   assert_output --partial 'Analysis Level: build'
-  assert_output --partial 'Build Log Mode: all'
+  assert_output --partial 'Build Log Mode: failed'
 }
 
 @test "Plugin does not show build_log_mode for step analysis" {

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -219,3 +219,36 @@ teardown() {
   assert_output --partial 'Claude Code Plugin (Post-Command)'
   assert_output --partial 'Triggering Claude analysis'
 }
+
+@test "Plugin shows build_log_mode when analysis_level is build" {
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANALYSIS_LEVEL='build'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILDKITE_API_TOKEN='bk-test-token'
+
+  run "$PWD"/hooks/post-command
+
+  assert_success
+  assert_output --partial 'Analysis Level: build'
+  assert_output --partial 'Build Log Mode: failed'
+}
+
+@test "Plugin uses custom build_log_mode" {
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANALYSIS_LEVEL='build'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILD_LOG_MODE='all'
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_BUILDKITE_API_TOKEN='bk-test-token'
+
+  run "$PWD"/hooks/post-command
+
+  assert_success
+  assert_output --partial 'Analysis Level: build'
+  assert_output --partial 'Build Log Mode: all'
+}
+
+@test "Plugin does not show build_log_mode for step analysis" {
+  export BUILDKITE_PLUGIN_CLAUDE_SUMMARIZE_ANALYSIS_LEVEL='step'
+
+  run "$PWD"/hooks/post-command
+
+  assert_success
+  assert_output --partial 'Analysis Level: step'
+  refute_output --partial 'Build Log Mode:'
+}

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -13,7 +13,7 @@ setup() {
 }
 
 @test "Validate configuration succeeds with valid inputs" {
-  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "false" ""
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "step" "false" "" "failed"
 
   assert_success
   refute_output --partial "Error"
@@ -104,4 +104,18 @@ setup() {
 
   assert_failure
   assert_output --partial "Error: jq is required"
+}
+
+@test "Validate configuration fails with invalid build_log_mode" {
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "build" "false" "" "invalid-mode"
+
+  assert_failure
+  assert_output --partial "Error: build_log_mode must be one of: failed, all"
+}
+
+@test "Validate configuration succeeds with build_log_mode all" {
+  run validate_configuration "sk-ant-test-key" "claude-3-opus" "on-failure" "build" "false" "bk-token" "all"
+
+  assert_success
+  refute_output --partial "Error"
 }


### PR DESCRIPTION
While using the `claude-summarize` plugin on a project with 15+ build steps using the `build` analysis_level, I constantly faced a 400 error from Claude API:
```json
{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 215160 tokens > 200000 maximum"},"request_id":"-"}
```

I tried to reduce the max log lines, but it didn't really seem to help in some cases. Then I noticed that the plugin always reports the logs from all jobs, failing and successful.
This PR aims to provide the option to let the user decide to only have failed jobs analyzed, therefore using less tokens in principle.